### PR TITLE
Fix typos in DataShift.TcPOU

### DIFF
--- a/Name/POUs/70_Data/DataShift.TcPOU
+++ b/Name/POUs/70_Data/DataShift.TcPOU
@@ -5,14 +5,14 @@
 VAR
 	bTestBitStart		:BOOL;
 	bTestBitEnd			:BOOL;	
-	i					:INT; //roop index
+	i					:INT; //loop index
 
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
 // Calculate process time
-	GVL_Status.fbLocalTime(bEnable := TRUE);	// Currnet Time
+	GVL_Status.fbLocalTime(bEnable := TRUE);	// Current Time
 	IF bTestBitStart AND GVL_Status.fbLocalTime.bValid THEN
 		astProductData[1].dtStartTime := SYSTEMTIME_TO_DT(GVL_Status.fbLocalTime.systemTime);
 	END_IF


### PR DESCRIPTION
## Summary
- fix comment typos in `DataShift.TcPOU`
- ensure file ends with newline

## Testing
- `git diff --stat --cached`


------
https://chatgpt.com/codex/tasks/task_e_6886f5e2fcd4832b857582d6a5b59808