### PR TITLE
Fix variable typos

### DIFF
--- a/Name/POUs/80_HMI/HMI.TcPOU
+++ b/Name/POUs/80_HMI/HMI.TcPOU
@@ -18,7 +18,7 @@ END_VAR
 // Select Auto Mode
 	IF GVL_Status.bAutoCmd = FALSE AND GVL_Status.bAutoBusy = FALSE AND GVL_Status.bManualBusy = FALSE AND GVL_Status.bHomeBusy = FALSE  THEN
 		//Turn On Auto Mode 
-		IF GVL_HMI.bBtAutoMode = TRUE AND GVL_Status.bAutoMode = FALSE AND GVL_Status.bSafetyDoorlocked THEN
+        IF GVL_HMI.bBtAutoMode = TRUE AND GVL_Status.bAutoMode = FALSE AND GVL_Status.bSafetyDoorLocked THEN
 			GVL_Status.bAutoMode := TRUE;
 			GVL_HMI.bBtAutoMode := FALSE;
 		END_IF
@@ -31,7 +31,7 @@ END_VAR
 		GVL_HMI.bBtAutoMode := FALSE;
 	END_IF
 		
-	IF GVL_Status.bSafetyDoorUnlocked OR (NOT bDoorUnlockCmd AND NOT bDoorlockCmd)  THEN
+        IF GVL_Status.bSafetyDoorUnlocked OR (NOT bDoorUnlockCmd AND NOT bDoorLockCmd)  THEN
 		GVL_HMI.bBtAutoMode := FALSE;
 	END_IF
 	

--- a/Name/POUs/99_FB/fbAlarm.TcPOU
+++ b/Name/POUs/99_FB/fbAlarm.TcPOU
@@ -29,8 +29,8 @@ END_VAR
     <Implementation>
       <ST><![CDATA[
 // Alarm Input
-	balarm	:= bCommand AND bAlarmCondition;
-	tonDelayTimer(in := balarm, pt :=tDelayTime);
+	bAlarm	:= bCommand AND bAlarmCondition;
+	tonDelayTimer(in := bAlarm, pt :=tDelayTime);
 
 // Alarm History
 	triAlarm(clk := tonDelayTimer.Q);
@@ -38,11 +38,11 @@ END_VAR
 		FOR i := cMaxAlarmLogCount TO 1 BY -1 DO
 			astAlarmHistory[i]	:= astAlarmHistory[i-1];
 		END_FOR
-		stalarminfo.iAlarmCode	:= iAlarmCode;
-		stalarminfo.iPriority	:= iPriority;
-		stalarminfo.sAlarmMessage	:= sAlarmMessage;
-		stalarminfo.sLocation	:= sLocation;
-		stalarminfo.tTimeStamp	:= SYSTEMTIME_TO_DT(GVL_Status.fbLocalTime.systemTime);
+		stAlarmInfo.iAlarmCode	:= iAlarmCode;
+		stAlarmInfo.iPriority	:= iPriority;
+		stAlarmInfo.sAlarmMessage	:= sAlarmMessage;
+		stAlarmInfo.sLocation	:= sLocation;
+		stAlarmInfo.tTimeStamp	:= SYSTEMTIME_TO_DT(GVL_Status.fbLocalTime.systemTime);
 		astAlarmHistory[0] := stAlarmInfo;
 	END_IF
 

--- a/Name/POUs/Test.TcPOU
+++ b/Name/POUs/Test.TcPOU
@@ -6,8 +6,8 @@ VAR
 
 	fbTestAlarm1: fbalarm;
 
-	bTes1: BOOL;
-	bTest11: BOOL;
+        bTestSelectWarning: BOOL;
+        bTestAlarmCondition: BOOL;
 	bTestError1: BOOL;
 	bTestWarning1: BOOL;
 END_VAR
@@ -26,10 +26,10 @@ END_VAR
 
 // Alarm
 	fbTestAlarm1(
-	bSelectWarning:= bTes1, 
+        bSelectWarning:= bTestSelectWarning,
 	tDelayTime:= T#1S, 
 	bCommand:= TRUE, 
-	bAlarmCondition:= bTest11, 
+        bAlarmCondition:= bTestAlarmCondition,
 	iAlarmCode:= 1, 
 	iPriority:= 1, 
 	sAlarmMessage:= 'hello', 


### PR DESCRIPTION
## Summary
- update typos in HMI function block
- correct variable names in alarm handling
- rename test variables for clarity

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6886f902fa90832b84a7ae7ad31131cd